### PR TITLE
Show the correct comment for excluded projects

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.3.13

--- a/src/sbt-test/bom/per-scala/build.sbt
+++ b/src/sbt-test/bom/per-scala/build.sbt
@@ -1,21 +1,38 @@
 import sbt._
 import sbt.Keys._
 
+val Scala212 = "2.12.11"
+
 val commonSettings =
-  Seq(organization := "com.lightbend", version := "4.3.2.1", crossScalaVersions := Seq("2.13.4", "2.12.11"))
+  Seq(organization := "com.lightbend", version := "4.3.2.1", crossScalaVersions := Seq("2.13.4", Scala212))
 
 lazy val core =
-  project.settings(commonSettings).settings(name := "scripted-core", crossScalaVersions := Seq("2.13.4", "2.12.11"))
+  project.settings(commonSettings).settings(name := "scripted-core")
+
+lazy val testingPlugin =
+  project
+    .settings(commonSettings)
+    .settings(
+      name := "testing-plugin",
+      crossScalaVersions := Seq(Scala212),
+      description := "A hypothetical sbt plugin which is not cross-compiled thus doesn't show in the Scala 2.13 BOM."
+    )
 
 lazy val nonScala =
-  project.settings(commonSettings).settings(name := "scripted-java", crossVersion := CrossVersion.disabled)
+  project
+    .settings(commonSettings)
+    .settings(
+      name := "scripted-java",
+      crossVersion := CrossVersion.disabled,
+      description := "A Java only project, without the Scala minor postfix in the artifact ID."
+    )
 
 lazy val billOfMaterials = project
   .enablePlugins(BillOfMaterialsPlugin)
   .settings(commonSettings)
   .settings(
     name := "sample-library-bom",
-    bomIncludeProjects := Seq(core, nonScala),
+    bomIncludeProjects := Seq(core, testingPlugin, nonScala),
     // added for testing only
     publishM2Configuration := publishM2Configuration.value.withOverwrite(true)
   )

--- a/src/sbt-test/bom/per-scala/expected/expected-2.12-pom.xml
+++ b/src/sbt-test/bom/per-scala/expected/expected-2.12-pom.xml
@@ -19,6 +19,11 @@
             </dependency>
             <dependency>
                 <groupId>com.lightbend</groupId>
+                <artifactId>testing-plugin_2.12</artifactId>
+                <version>4.3.2.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.lightbend</groupId>
                 <artifactId>scripted-java</artifactId>
                 <version>4.3.2.1</version>
             </dependency>

--- a/src/sbt-test/bom/per-scala/expected/expected-2.13-pom.xml
+++ b/src/sbt-test/bom/per-scala/expected/expected-2.13-pom.xml
@@ -17,6 +17,7 @@
                 <artifactId>scripted-core_2.13</artifactId>
                 <version>4.3.2.1</version>
             </dependency>
+            <!-- testing-plugin is not available for Scala 2.13 -->
             <dependency>
                 <groupId>com.lightbend</groupId>
                 <artifactId>scripted-java</artifactId>


### PR DESCRIPTION
As it shows in view-source:https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/play/play-bom_2.13/2.8.1+763-992e21bd-SNAPSHOT/play-bom_2.13-2.8.1+763-992e21bd-SNAPSHOT.pom the comment for artefacts that are skipped from a BOM showed the wrong version.

This sorts that out.